### PR TITLE
Add requiresMainQueueSetup to prevent warning

### DIFF
--- a/ios/RNOS.m
+++ b/ios/RNOS.m
@@ -78,6 +78,11 @@ static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
     };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 - (NSDictionary*)networkInterfaces {
     NSMutableDictionary* ifaces = [NSMutableDictionary new];
     struct ifaddrs *addrs, *ent;


### PR DESCRIPTION
RCCManagerModule will throw a warning if `constantsToExport` is overridden, but no `requiresMainQueueSetup` is found.

Since RNOS does not need the main UI thread (which is what that method is for) we can safely return `NO` from that method.