### PR TITLE
Pull info from app build.gradle if available; Use implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,7 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     repositories {
         jcenter()
@@ -11,12 +15,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    safeExtGet('compileSdkVersion', 23)
+    safeExtGet('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        safeExtGet('minSdkVersion', 16)
+        safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "0.2.0"
     }


### PR DESCRIPTION
**Breaking change**

Fixes android build errors on newer android API versions `Task :react-native-os:verifyReleaseResources FAILED`

- Pulls build.gradle vars like `compileSdkVersion` from the parent app if available
- Use `implementation` instead of `compile`to support gradle 3

More info: https://stackoverflow.com/questions/44493378/whats-the-difference-between-implementation-and-compile-in-gradle