### PR TITLE
Use implementation instead of compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,5 +44,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
In stable version of Android Studio, it is recommended to use
implementation not compile.
This is because the use of compile is deprecated in the Gradle version used in stable version of  Android Studio.

--- 

And, now, I'm requested to release newer version of react-native-os on npm.
version 1.2.4 of react-native-os's code is wrong.
it is not compiled on Android Studio because react-native-os/android/build.gradle is not newest version.
probably used  <https://github.com/aprock/react-native-os/commit/12f1eed0cec0e164fc80bee92bf293940d68e227#diff-7ae5a9093507568eabbf35c3b0665732>

So please update react-native-os npm packagege.
thanks.