### PR TITLE
Fix pod validation

### DIFF
--- a/RNOS.podspec
+++ b/RNOS.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description         = package['description']
   s.homepage            = package['homepage']
   s.license             = package['license']
-  s.author              = package['author']
+  s.author              = "PeelTechnologies"
   s.source              = { :git => 'https://github.com/aprock/react-native-os.git' }
   s.platform              = :ios, '9.0'
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
Doing a `pod install` throws this error
```
[!] The `RNOS` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `authors`.
    - WARN  | source: Git sources should specify a tag.
    - WARN  | description: The description is equal to the summary.
```
according to https://guides.cocoapods.org/syntax/podspec.html#authors author/authors is required, currently it's getting imported from `package.json` but the attribute is missing in it.
