### PR TITLE
chore/remove duplicate key in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "bundleDependencies": false,
   "deprecated": false,
-  "description": "node's os module for react-native",
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "eslint-plugin-react": "^3.11.3"
@@ -33,10 +32,5 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/aprock/react-native-os/issues"
-  },
-  "homepage": "https://github.com/aprock/react-native-os",
-  "devDependencies": {
-    "babel-eslint": "^4.1.6",
-    "eslint-plugin-react": "^3.11.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "ios",
     "android"
   ],
+  "author": {
+    "name": "Andy Prock",
+    "email": "aprock@gmail.com"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/aprock/react-native-os/issues"


### PR DESCRIPTION
- fix: ios pod install failed by no auther field
- chore: remove duplicate key in package.json
