### PR TITLE
fix: ios pod install issue as podspec does not have an author

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.7",
   "description": "node's os module for react-native",
   "main": "index.js",
+  "author": "aprock",
   "scripts": {
     "start": "exit 1"
   },


### PR DESCRIPTION
Installing this module as a Pod fails with the following error
<img width="587" alt="image" src="https://user-images.githubusercontent.com/34555296/226217297-7fb6bf33-86df-4d4f-ae00-cc6065c8c232.png">

Because it is missing the author/authors property.
I've added @aprock your name to the package.json, which fixes this issue.